### PR TITLE
FileRecognition: add mka and webm types

### DIFF
--- a/audiobook/src/main/java/de/ph1b/audiobook/misc/FileRecognition.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/misc/FileRecognition.kt
@@ -42,6 +42,7 @@ object FileRecognition {
                 "m4b",
                 "mp4",
                 "mid",
+                "mka",
                 "mkv",
                 "mp3",
                 "mp3package",
@@ -52,6 +53,7 @@ object FileRecognition {
                 "rtttl",
                 "rtx",
                 "wav",
+                "webm",
                 "wma",
                 "xmf"
         )


### PR DESCRIPTION
The recommended file extension for audio only matroska is "mka":

https://www.matroska.org/technical/guides/faq/index.html

webm can be audio only as well, but they don't recommend another file
extension, only a different mime type:

http://www.webmproject.org/docs/container/