### PR TITLE
Allow faster playback speed and more fine-grained control

### DIFF
--- a/audiobook/src/main/java/de/ph1b/audiobook/Book.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/Book.kt
@@ -34,7 +34,7 @@ data class Book(val id: Long,
 
     companion object {
         const val ID_UNKNOWN = -1L
-        const val SPEED_MAX = 2F
+        const val SPEED_MAX = 6F
         const val SPEED_MIN = 0.5F
     }
 

--- a/audiobook/src/main/java/de/ph1b/audiobook/features/settings/dialogs/PlaybackSpeedDialogFragment.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/features/settings/dialogs/PlaybackSpeedDialogFragment.kt
@@ -29,7 +29,7 @@ class PlaybackSpeedDialogFragment : DialogFragment() {
     @Inject lateinit var db: BookChest
     @Inject lateinit var playerController: PlayerController
 
-    private val SPEED_DELTA = 0.02f
+    private val SPEED_DELTA = 0.01f
     private val MAX_STEPS = Math.round((Book.SPEED_MAX - Book.SPEED_MIN) / SPEED_DELTA)
     private val df = DecimalFormat("0.00")
 


### PR DESCRIPTION
# Information
## Why do we need to listen faster than 2x?
Audible is a comparable to this app, and it let's its user listen to books [3 times faster](http://audible.custhelp.com/app/answers/detail/a_id/4795/~/how-can-i-adjust-the-playback-speed-in-the-audible-for-android-app%3F) than they were recorded. Listening to books faster than normal is actually a very common thing to do. It allows you to finish books faster and I make heavy use of it in the Audible app. I casually listen to books on audible at 3 and would love them to go even higher (say 4-5) but it all depends on the book and the reader. This brings up a problem when I switch to using DRM free books and turn to MaterialAudiobookPlayer.

## "People won't use it"
So far there are four open issues on the subject, my own included. That means that at least 4 people would use it. I can tell you for a fact that many more would. I also don't understand how not making an option more flexible would deter people from using it. In fact I am very much deterred from using the player with the speed settings how they currently are because I listen to books so much faster. 

Here are some references with anecdotal evidence on why people listen to books at faster speeds.

* http://www.geekybloggersbookblog.com/listening-to-audiobooks-at-a-faster-speed/
* http://www.everyday-reading.com/2013/06/how-to-listen-to-audiobooks-on-double.html
* https://medium.com/ios-os-x-development/i-built-a-speed-listening-app-c6d2e3704713#.gg21707lm

# Changes
* Allow users to select playback speeds up to 6x normal
  * #472, #458, #440, #255 
* Allow users to select playback speeds in increments of 0.01
  * The current rate of 0.02 is just annoying, if we want to restrict this it should be in increments of 0.05