### PR TITLE
Use title from meta data for book name if album is undefined

### DIFF
--- a/audiobook/src/main/java/de/ph1b/audiobook/misc/MediaAnalyzer.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/misc/MediaAnalyzer.kt
@@ -44,7 +44,9 @@ object MediaAnalyzer {
       if (author.isNullOrEmpty())
         author = mmr.safeExtract(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
 
-      val bookName = mmr.safeExtract(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+      var bookName = mmr.safeExtract(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+      if (bookName.isNullOrEmpty())
+        bookName = chapterName
 
       return Result(duration, chapterName!!, author, bookName)
     } catch(ignored: RuntimeException) {


### PR DESCRIPTION
This PR makes the media scanner use `METADATA_KEY_TITLE` for `bookName` if `METADATA_KEY_ALBUM` is undefined.

Use case: You have an audio book mp3 file with only Title and Artist ID3 tags set.
MaterialAudiobookPlayer expects the album tag to contain the book's title and therefor ignore the title tag.
This PR fixes this behaviour.