### PR TITLE
show covers when listing books on Android wear

### DIFF
--- a/audiobook/src/main/AndroidManifest.xml
+++ b/audiobook/src/main/AndroidManifest.xml
@@ -105,6 +105,15 @@
           android:name="android.appwidget.provider"
           android:resource="@xml/widget_info"/>
     </receiver>
+      <provider
+          android:name="android.support.v4.content.FileProvider"
+          android:authorities="de.ph1b.audiobook.coverprovider"
+          android:exported="false"
+          android:grantUriPermissions="true">
+          <meta-data
+              android:name="android.support.FILE_PROVIDER_PATHS"
+              android:resource="@xml/cover_paths" />
+      </provider>
   </application>
 
 </manifest>

--- a/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
@@ -1,6 +1,7 @@
 package de.ph1b.audiobook.playback.utils
 
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.net.Uri
 import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.MediaBrowserServiceCompat
@@ -39,6 +40,7 @@ import javax.inject.Inject
         MediaDescriptionCompat.Builder()
             .setTitle("${context.getString(R.string.current_book)}: ${it.name}")
             .setMediaId(bookUriConverter.book(it.id).toString())
+            .setIconBitmap(BitmapFactory.decodeFile(it.coverFile().absolutePath))
             .build().let {
           MediaBrowserCompat.MediaItem(it, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
         }
@@ -48,6 +50,7 @@ import javax.inject.Inject
         val description = MediaDescriptionCompat.Builder()
             .setTitle(it.name)
             .setMediaId(bookUriConverter.book(it.id).toString())
+            .setIconBitmap(BitmapFactory.decodeFile(it.coverFile().absolutePath))
             .build()
         return@map MediaBrowserCompat.MediaItem(description, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
       }

--- a/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
@@ -38,7 +38,8 @@ import javax.inject.Inject
     val match = bookUriConverter.match(uri)
 
     if (match == BookUriConverter.ROOT) {
-      val current = repo.bookById(prefs.currentBookId.value)?.let {
+      val currentBook = repo.bookById(prefs.currentBookId.value)
+      val current = currentBook?.let {
         val coverFile = it.coverFile()
         MediaDescriptionCompat.Builder()
             .setTitle("${context.getString(R.string.current_book)}: ${it.name}")
@@ -54,7 +55,8 @@ import javax.inject.Inject
         }
       }
 
-      val all = repo.activeBooks.map {
+      // do NOT return the current book twice as this will break the listing due to stable IDs
+      val all = repo.activeBooks.filter { it != currentBook }.map {
         val coverFile = it.coverFile()
         val description = MediaDescriptionCompat.Builder()
             .setTitle(it.name)

--- a/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
+++ b/audiobook/src/main/java/de/ph1b/audiobook/playback/utils/MediaBrowserHelper.kt
@@ -46,6 +46,7 @@ import javax.inject.Inject
             .setIconUri(if (coverFile.exists()) {
               val uriForFile = FileProvider.getUriForFile(context, "de.ph1b.audiobook.coverprovider", coverFile)
               context.grantUriPermission("com.google.android.wearable.app", uriForFile, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+              context.grantUriPermission("com.google.android.projection.gearhead", uriForFile, Intent.FLAG_GRANT_READ_URI_PERMISSION)
               uriForFile
             } else null)
             .build().let {
@@ -61,6 +62,7 @@ import javax.inject.Inject
             .setIconUri(if (coverFile.exists()) {
               val uriForFile = FileProvider.getUriForFile(context, "de.ph1b.audiobook.coverprovider", coverFile)
               context.grantUriPermission("com.google.android.wearable.app", uriForFile, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+              context.grantUriPermission("com.google.android.projection.gearhead", uriForFile, Intent.FLAG_GRANT_READ_URI_PERMISSION)
               uriForFile
             } else null)
             .build()

--- a/audiobook/src/main/res/xml/cover_paths.xml
+++ b/audiobook/src/main/res/xml/cover_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="covers" path="Android/data/de.ph1b.audiobook/"/>
+</paths>


### PR DESCRIPTION
I saw that when listing the books on Android wear the cover images are missing. It feels like this is not an ideal solution for the tiny thumbnails (perhaps we should scale the image in the call), but it looks very nice.

@PaulWoitaschek What's your opinion on this?