### PR TITLE
Fix compile error because of missing include file

### DIFF
--- a/exoplayer-flac/src/main/jni/flac_parser.cc
+++ b/exoplayer-flac/src/main/jni/flac_parser.cc
@@ -22,6 +22,7 @@
 
 #include <cassert>
 #include <cstdlib>
+#include <cstring>
 
 #define LOG_TAG "FLACParser"
 #define ALOGE(...) \


### PR DESCRIPTION
When compiling on my machine I get error:
```
Compile++      : flacJNI <= flac_parser.cc
/home/p2004a/Workspace/MaterialAudiobookPlayer/exoplayer-flac/src/main/jni/flac_parser.cc:281:3: error: use of undeclared identifier 'memset'
  memset(&mStreamInfo, 0, sizeof(mStreamInfo));
  ^
/home/p2004a/Workspace/MaterialAudiobookPlayer/exoplayer-flac/src/main/jni/flac_parser.cc:282:3: error: use of undeclared identifier 'memset'
  memset(&mWriteHeader, 0, sizeof(mWriteHeader));
  ^
```
Adding missing header file fixes it.